### PR TITLE
Added the name of qsub_file used for the test in the report.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ When the Nextflow pipeline finishes, a CSV file containing the same name as the 
 | -------------                    | ------------- |
 | job_number                       | The job number for the job. |
 | hostname                         | The hostname of the node the job ran on. |
+| qsub_file                        | The qsub file used for the test. |
 | test_result<sup>1</sup>          | The overall test result. e.g PASSED or FAILED |
 | module                           | Name of the module tested.  |
 | tests_passed                     | Number of times the word "Passed" was found in the stdout stream of the test.qsub run.  |

--- a/nextflow/pkgtest.nf
+++ b/nextflow/pkgtest.nf
@@ -98,8 +98,8 @@ process runTests {
 
     # WRITE THE TEST RESULT INFORMATION TO A CSV FILE
 cat > test_metrics.csv << EOF
-job_number, hostname, test_result,module, tests_passed, tests_failed, log_error_count, exit_code, installer, category, install_date,  workdir
-\$JOB_ID, \$HOSTNAME, \$TEST_RESULT, $module_name_version, \$PASSED, \$FAILED, \$LOG_ERRORS, \$EXIT_CODE, $module_installer, $module_category, $module_install_date, \$PWD
+job_number, hostname, qsub_file, test_result,module, tests_passed, tests_failed, log_error_count, exit_code, installer, category, install_date,  workdir
+\$JOB_ID, \$HOSTNAME, \$QSUB_FILE, \$TEST_RESULT, $module_name_version, \$PASSED, \$FAILED, \$LOG_ERRORS, \$EXIT_CODE, $module_installer, $module_category, $module_install_date, \$PWD
 EOF
 
     """


### PR DESCRIPTION
Added a new column to the generated test result report that contains the qsub filename used for the test.  This is to address issue #32.