### PR TITLE
Added `--keep_passed` nextflow argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ One can also run all the tests on the host machine by setting the `--executor` f
 nextflow pkgtest.nf --csv_input module_list.csv  --executor local
 ```
 
+If you wish to have the nextflow pipeline delete the test directory if a module test passes, then set `--keep_passed` to `false`.  By default this value is set to `true`:
+
+```bash
+nextflow pkgtest.nf --csv_input module_list.csv  --keep_passed false
+```
+
 If a process failed, check the [Troubleshooting](#troubleshooting) section, otherwise proceed to [Step 3](#step-3---review-the-results) to review the test results.
 
 NOTE: You can resume a Nextflow process if it terminated early, so one does not lose all the progress.  This can be done by adding a [`-resume`](https://training.nextflow.io/basic_training/cache_and_resume/) flag to the command. This will use the cached results from the last Nextflow run and resume from the last successful process.

--- a/nextflow/pkgtest.nf
+++ b/nextflow/pkgtest.nf
@@ -52,8 +52,6 @@ process runTests {
     ## COPY TEST DIRECTORY INTO WORK DIRECTORY 
     cp -r \$TEST_DIR \$WORKDIR
 
-    # CD INTO TEST DIRECTORY
-    cd `basename \$TEST_DIR`
 
     ## PRINT ENVIRONMENT VARIABLES ASSOCIATED WITH THE TEST
     echo MODULE=$module_name_version
@@ -68,6 +66,11 @@ process runTests {
     echo WORKDIR=\$WORKDIR
     echo USER=\$USER
     echo keep_passed=${params.keep_passed}
+
+    # CD INTO TEST DIRECTORY
+    BASE_NAME=`basename \$TEST_DIR` 
+    NF_TEST_DIR=\$WORKDIR/\$BASE_NAME     # GET THE NAME OF THE TEST DIRECTORY
+    cd \$NF_TEST_DIR
 
     ## APPEND XVFB KILL COMMAND TO QSUB FILE (see issue #18 https://github.com/bu-rcs/PkgAutoTest/issues/18)
     echo '\n#### CODE BLOCK INSERTED BY NEXTFLOW ####' >> \$QSUB_FILE
@@ -112,7 +115,7 @@ EOF
     elif [[ \$TEST_RESULT == PASSED &&  ${params.keep_passed} == false ]]
     then
         echo "Parameter keep_passed=${params.keep_passed} and test result is \$TEST_RESULT, therefore deleting the test directory."
-        rm -rf \$WORKDIR/\$TEST_DIR
+        rm -rf \$NF_TEST_DIR
     fi
 
     """

--- a/nextflow/pkgtest.nf
+++ b/nextflow/pkgtest.nf
@@ -5,6 +5,7 @@ params.errorStrategy = 'ignore' // "ignore"- will continue with other tests if t
 			    // "terminate" - kill all tests when error is encountered
 params.qsub_path = ""
 params.project = "rcstest"  // Value to be used for the -P directive for qsub
+params.keep_passed = "true" // If true, the passed tests will be kept in the output directory
 
 nextflow.enable.dsl=2
 
@@ -66,6 +67,7 @@ process runTests {
     echo RESULTS=\$RESULTS
     echo WORKDIR=\$WORKDIR
     echo USER=\$USER
+    echo keep_passed=${params.keep_passed}
 
     ## APPEND XVFB KILL COMMAND TO QSUB FILE (see issue #18 https://github.com/bu-rcs/PkgAutoTest/issues/18)
     echo '\n#### CODE BLOCK INSERTED BY NEXTFLOW ####' >> \$QSUB_FILE
@@ -101,6 +103,17 @@ cat > test_metrics.csv << EOF
 job_number, hostname, qsub_file, test_result,module, tests_passed, tests_failed, log_error_count, exit_code, installer, category, install_date,  workdir
 \$JOB_ID, \$HOSTNAME, \$QSUB_FILE, \$TEST_RESULT, $module_name_version, \$PASSED, \$FAILED, \$LOG_ERRORS, \$EXIT_CODE, $module_installer, $module_category, $module_install_date, \$PWD
 EOF
+
+
+    # Check if the test directory should be kept or deleted based on the test result and keep_passed parameter
+    if [[ \$TEST_RESULT == PASSED &&  ${params.keep_passed} == true ]]
+    then
+        echo "Parameter keep_passed=${params.keep_passed}, keeping the test directory."
+    elif [[ \$TEST_RESULT == PASSED &&  ${params.keep_passed} == false ]]
+    then
+        echo "Parameter keep_passed=${params.keep_passed} and test result is \$TEST_RESULT, therefore deleting the test directory."
+        rm -rf \$WORKDIR/\$TEST_DIR
+    fi
 
     """
 }


### PR DESCRIPTION
This pull request satisfies enhancement request #12 .  The Nextflow pipeline now has a `--keep_passed` parameter that can have either `true` or `false` values.

- `true` - the module working `test` directory is not deleted.
- `false` - the module working `test` directory is deleted if the test passes.

Note: The default value set in `pkgtest.nf` is `true` to retain the `test` directory by default.  When running the monthly test, the parameter can be set to `false` to save on storage space.

**Example Command**:
```bash
nextflow pkgtest.nf --csv_input module_list.csv --keep_passed false
```
