### PR TITLE
Strip inline comments from #$ directives so later qsub options are not dropped

### DIFF
--- a/scripts/find_qsub.py
+++ b/scripts/find_qsub.py
@@ -212,7 +212,14 @@ class SccModule():
             for line in f:
                 # if it starts with #$ it's a qsub command.
                 if line.startswith('#$'):
-                    qsub_cmds.append(line.split('$')[1].strip())
+                    # Drop an inline comment before the directives are joined
+                    # into a single line below. SGE reads each #$ line on its
+                    # own and ignores the rest of that line after a '#', but
+                    # once joined a surviving '#' comments out every option
+                    # that follows it. See issue #49.
+                    cmd = line.split('$')[1].split('#')[0].strip()
+                    if cmd:
+                        qsub_cmds.append(cmd)
 
             def startswith(elem):
                 has_no_flags = False

--- a/tests/test_extract_qsub_opts.py
+++ b/tests/test_extract_qsub_opts.py
@@ -1,0 +1,75 @@
+"""Unit tests for SccModule.extract_qsub_opts() in find_qsub.py.
+
+The qsub options of every #$ directive in a test.qsub are joined into the single
+`qsub_options` CSV column, which pkgtest.nf hands to SGE as one clusterOptions
+line.  A '#' that survives that join comments out every option after it, so the
+per-directive comments have to be removed while the directives are still on
+separate lines.  See issue #49.
+"""
+
+import importlib.util
+import os
+
+FIND_QSUB = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                         'scripts', 'find_qsub.py')
+
+
+def load_find_qsub():
+    ''' Import find_qsub.py by path - it is a script, not an installed module. '''
+    spec = importlib.util.spec_from_file_location('find_qsub', FIND_QSUB)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def write_qsub(tmp_path, *directives):
+    ''' Write a minimal test.qsub containing the given #$ directive lines. '''
+    qsub = tmp_path / 'test.qsub'
+    qsub.write_text('#!/bin/bash -l\n' + '\n'.join(directives) + '\n\nmodule list\n')
+    return str(qsub)
+
+
+def extract(tmp_path, *directives):
+    ''' Extract the qsub options from a test.qsub built from these directives. '''
+    SccModule = load_find_qsub().SccModule
+    return SccModule.extract_qsub_opts(None, write_qsub(tmp_path, *directives))
+
+
+def test_inline_comment_does_not_hide_later_options(tmp_path):
+    ''' The shapeit/5.1.1 case from issue #49: -l avx512 follows a commented
+        directive and must still reach SGE. '''
+    opts = extract(tmp_path,
+                   '#$ -pe omp 4 # Use 4 CPUs',
+                   '#$ -l avx512 # Request a node that supports AVX512 and newer CPU instructions')
+
+    assert opts == '-pe omp 4 -l avx512'
+    # No '#' may survive: SGE drops everything after one.
+    assert '#' not in opts
+
+
+def test_options_without_comments_are_unchanged(tmp_path):
+    ''' Directives that carry no comment keep their existing behavior. '''
+    opts = extract(tmp_path, '#$ -pe mpi_16_tasks_per_node 32', '#$ -l h_rt=12:00:00')
+
+    assert opts == '-pe mpi_16_tasks_per_node 32 -l h_rt=12:00:00'
+
+
+def test_ignored_flags_are_still_dropped(tmp_path):
+    ''' -j, -P and -N are supplied by pkgtest.nf and stay filtered out, with or
+        without a comment. '''
+    opts = extract(tmp_path,
+                   '#$ -P scv # set by the pipeline',
+                   '#$ -N my_test',
+                   '#$ -j y',
+                   '#$ -l mem_per_core=8G')
+
+    assert opts == '-l mem_per_core=8G'
+
+
+def test_comment_only_directive_contributes_nothing(tmp_path):
+    ''' A directive commented out in place adds no options - and no stray text
+        for the --gpus-only / --no-gpus filters to match on. '''
+    opts = extract(tmp_path, '#$ -pe omp 4', '#$ # -l gpus=1 disabled for now')
+
+    assert opts == '-pe omp 4'
+    assert '-l gpus' not in opts


### PR DESCRIPTION
This PR proposes stripping inline comments from `#$` directives in `find_qsub.py` so that a commented directive no longer silences the resource requests that follow it (issue #49). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/316. You can sign in with your GitHub ID to claim ownership of the project.

## What changed and why

`SccModule.extract_qsub_opts()` reads each `#$` line from a `test.qsub` and joins them all into the single `qsub_options` CSV column, which `pkgtest.nf` then hands to SGE as one `clusterOptions` line. As issue #49 records, SGE ignores everything after a `#` on that line — so once the directives are joined, a comment on an early directive comments out every option after it. In the `shapeit/5.1.1` case from that issue, `-l avx512` was dropped and the test ran on a node without those instructions.

The fix removes each directive's comment while the directives are still on separate lines, which is the same per-line reading SGE applies to the file itself. A directive line that is entirely a comment now contributes nothing instead of an empty entry. Directives without comments produce byte-identical output, and the existing `-j` / `-P` / `-N` filtering is unchanged, so nothing already working moves.

This is worth doing in the tooling as well as in the guidance already noted on the issue, because the failure is silent and the existing `qsub -w p` validation cannot catch it: SGE reads `test.qsub` line by line, where the comment is harmless, so the file validates as good and the corruption appears only after the join. There is a second effect the same `#` causes — `gpu_filter_tests()` matches `-l gpus` anywhere in that joined string, so comment text mentioning GPUs can misroute a test under `--gpus-only` / `--no-gpus`.

**Reproduction on `main` at `c5a5f00`**, with a `test.qsub` holding the two directives quoted in the issue:

```
$ python3 -c "
import importlib.util
s = importlib.util.spec_from_file_location('fq','scripts/find_qsub.py')
m = importlib.util.module_from_spec(s); s.loader.exec_module(m)
print(repr(m.SccModule.extract_qsub_opts(None,'/tmp/test.qsub')))"
'-pe omp 4 # Use 4 CPUs -l avx512 # Request a node that supports AVX512 and newer CPU instructions'
```

Feeding that column through the real `to_csv_rows()` / `save_csv()` writer and reading it back the way `pkgtest.nf` does gives the `clusterOptions` line `-P rcstest -N nf_shapeit_5.1.1 -pe omp 4 # Use 4 CPUs -l avx512 # ...`, of which SGE parses only `-P rcstest -N nf_shapeit_5.1.1 -pe omp 4`. With this change the same end-to-end run yields `-P rcstest -N nf_shapeit_5.1.1 -pe omp 4 -l avx512`.

**Verification.** `tests/test_extract_qsub_opts.py` covers the commented case, the uncommented case, the ignored-flag filtering, and a directive commented out in place. Two of the four fail on the current tree (`assert '-pe omp 4 # Use 4 CPUs -l avx512 # ...' == '-pe omp 4 -l avx512'`) and all four pass with the change; the other two are controls that pass in both states, which is what shows existing behavior is untouched. There is no test harness or CI on `main` today, so the before/after comparison is that file plus `python3 -m py_compile scripts/find_qsub.py`, both clean before and after — no new failures. The tests are plain pytest functions in a `tests/` directory and add no dependency beyond what `find_qsub.py` already imports, so they sit alongside the suite proposed in #53 rather than competing with it.

`#$` directives are left in `test.qsub` files untouched; only the extracted option string changes.

## How this was managed

We imported your issues and pull requests onto a live agile board — 56 stories — and worked this change on the story for issue #49, https://eastagiletracker.com/projects/316/stories/204444, with the rest of the history on the board at https://eastagiletracker.com/projects/316.

![board](https://raw.githubusercontent.com/eastagiletracker/PkgAutoTest/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
